### PR TITLE
Use ansible local provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This project offers environment for all the labs in **Red Hat RHCSA/RHCE 7 Cert 
 ## install dependencies:
 - [Virtualbox](https://www.virtualbox.org): cross-platform virtualization application.
 - [Vagrant](https://www.vagrantup.com): tool for building complete development environments. With an easy-to-use workflow and focus on automation
-- [Ansible](https://www.ansible.com):  free-software platform for configuring and managing computers which combines multi-node software deployment, ad hoc task execution, and configuration management.
 
 Don't worry you don't have to be expert on any of these tools.
 ### 1. Install virtualbox :
@@ -75,24 +74,6 @@ $ sudo rpm -ivh vagrant_1.8.5_x86_64.rpm
 $ wget https://releases.hashicorp.com/vagrant/1.8.5/vagrant_1.8.5_i686.rpm
 
 $ sudo rpm -ivh vagrant_1.8.5_i686.rpm
-```
-### 3. Install ansible :
-**3.1 Install ansible on Debian-based distributions (Ubuntu/Mint):**
-```shell
-$ sudo apt-get install gcc libssl-dev python-dev python-setuptools
-
-$ sudo easy_install pip
-
-$ sudo pip install ansible netaddr
-```
-
-**3.2 Install ansible on RedHat-based distributions:**
-```shell
-$ sudo yum install gcc openssl-devel python-devel python-setuptools
-
-$ sudo easy_install pip
-
-$ sudo pip install ansible netaddr
 ```
 
 ## Get environment

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.memory = "512"
       vb.name = "cache-server"
     end
-    node.vm.provision "ansible" do |ansible|
+    node.vm.provision :ansible_local do |ansible|
+      ansible.install_mode = "pip"
+      ansible.version = "2.2"
       ansible.playbook = "provisioning/cache-server.yml"
     end
   end
@@ -42,7 +44,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.name = "labipa"
     end
     # provision machine using ansible
-    node.vm.provision :ansible do |ansible|
+    node.vm.provision :ansible_local do |ansible|
+      ansible.install_mode = "pip"
+      ansible.version = "2.2"
+      ansible.provisioning_path = "/home/vagrant/sync"
       ansible.host_vars = { "labipa" => { "private_ipv4_address" => "192.168.4.200" , "private_ipv6_address" => "fd00::200" }}
       ansible.playbook = "provisioning/labipa.yml"
     end
@@ -78,7 +83,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       # provision machine using ansible
-      node.vm.provision "ansible" do |ansible|
+      node.vm.provision :ansible_local do |ansible|
+        ansible.install_mode = "pip"
+        ansible.version = "2.2"
+        ansible.provisioning_path = "/home/vagrant/sync"
         ansible.host_vars = { "server#{i}" => { "private_ipv4_address" => "192.168.4.2#{i}0" , "private_ipv6_address" => "fd00::2#{i}0" } }
         ansible.playbook = "provisioning/servers.yml"
       end

--- a/provisioning/labipa/tasks/main.yml
+++ b/provisioning/labipa/tasks/main.yml
@@ -34,7 +34,7 @@
     	--realm={{ ipa_realm }} \
     	--ds-password={{ ldap_directory_manager_password }} \
     	--admin-password={{ ipa_admin_password }} \
-    	--forwarder={{ ansible_dns.nameservers[0] }} \
+    	--forwarder={{ primary_dns }} \
     	--reverse-zone={{ reverse_dns }} \
     	--unattended
     "


### PR DESCRIPTION
Use ansible_local provisioner instead of ansible remote default provisioner by doing so we:

- reduce environment dependencies.
- make installation easier on Windows no need to install ansible.