### PR TITLE
Local ansible smartbit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This project offers environment for all the labs in **Red Hat RHCSA/RHCE 7 Cert 
 ## install dependencies:
 - [Virtualbox](https://www.virtualbox.org): cross-platform virtualization application.
 - [Vagrant](https://www.vagrantup.com): tool for building complete development environments. With an easy-to-use workflow and focus on automation
-- [Ansible](https://www.ansible.com):  free-software platform for configuring and managing computers which combines multi-node software deployment, ad hoc task execution, and configuration management.
 
 Don't worry you don't have to be expert on any of these tools.
 ### 1. Install virtualbox :
@@ -75,24 +74,6 @@ $ sudo rpm -ivh vagrant_1.8.5_x86_64.rpm
 $ wget https://releases.hashicorp.com/vagrant/1.8.5/vagrant_1.8.5_i686.rpm
 
 $ sudo rpm -ivh vagrant_1.8.5_i686.rpm
-```
-### 3. Install ansible :
-**3.1 Install ansible on Debian-based distributions (Ubuntu/Mint):**
-```shell
-$ sudo apt-get install gcc libssl-dev python-dev python-setuptools
-
-$ sudo easy_install pip
-
-$ sudo pip install ansible netaddr
-```
-
-**3.2 Install ansible on RedHat-based distributions:**
-```shell
-$ sudo yum install gcc openssl-devel python-devel python-setuptools
-
-$ sudo easy_install pip
-
-$ sudo pip install ansible netaddr
 ```
 
 ## Get environment

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.memory = "512"
       vb.name = "cache-server"
     end
-    node.vm.provision "ansible" do |ansible|
+    node.vm.provision :ansible_local do |ansible|
+      ansible.install_mode = "pip"
+      ansible.version = "2.2"
       ansible.playbook = "provisioning/cache-server.yml"
     end
   end
@@ -42,7 +44,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.name = "labipa"
     end
     # provision machine using ansible
-    node.vm.provision :ansible do |ansible|
+    node.vm.provision :ansible_local do |ansible|
+      ansible.install_mode = "pip"
+      ansible.version = "2.2"
+      ansible.provisioning_path = "/home/vagrant/sync"
       ansible.host_vars = { "labipa" => { "private_ipv4_address" => "192.168.4.200" , "private_ipv6_address" => "fd00::200" }}
       ansible.playbook = "provisioning/labipa.yml"
     end
@@ -78,7 +83,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       # provision machine using ansible
-      node.vm.provision "ansible" do |ansible|
+      node.vm.provision :ansible_local do |ansible|
+        ansible.install_mode = "pip"
+        ansible.version = "2.2"
+        ansible.provisioning_path = "/home/vagrant/sync"
         ansible.host_vars = { "server#{i}" => { "private_ipv4_address" => "192.168.4.2#{i}0" , "private_ipv6_address" => "fd00::2#{i}0" } }
         ansible.playbook = "provisioning/servers.yml"
       end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     node.vm.provision :ansible_local do |ansible|
       ansible.install_mode = "pip"
-      ansible.version = "2.2"
       ansible.playbook = "provisioning/cache-server.yml"
     end
   end
@@ -45,9 +44,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     # provision machine using ansible
     node.vm.provision :ansible_local do |ansible|
-      ansible.install_mode = "pip"
-      ansible.version = "2.2"
-      ansible.provisioning_path = "/home/vagrant/sync"
       ansible.host_vars = { "labipa" => { "private_ipv4_address" => "192.168.4.200" , "private_ipv6_address" => "fd00::200" }}
       ansible.playbook = "provisioning/labipa.yml"
     end
@@ -84,9 +80,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       # provision machine using ansible
       node.vm.provision :ansible_local do |ansible|
-        ansible.install_mode = "pip"
-        ansible.version = "2.2"
-        ansible.provisioning_path = "/home/vagrant/sync"
         ansible.host_vars = { "server#{i}" => { "private_ipv4_address" => "192.168.4.2#{i}0" , "private_ipv6_address" => "fd00::2#{i}0" } }
         ansible.playbook = "provisioning/servers.yml"
       end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     node.vm.provision :ansible_local do |ansible|
       ansible.install_mode = "pip"
+      ansible.version = "2.2"
       ansible.playbook = "provisioning/cache-server.yml"
     end
   end
@@ -44,8 +45,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     # provision machine using ansible
     node.vm.provision :ansible_local do |ansible|
+      ansible.install_mode = "pip"
+      ansible.version = "2.2"
       ansible.host_vars = { "labipa" => { "private_ipv4_address" => "192.168.4.200" , "private_ipv6_address" => "fd00::200" }}
-      ansible.playbook = "provisioning/labipa.yml"
     end
   end
 
@@ -80,8 +82,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       # provision machine using ansible
       node.vm.provision :ansible_local do |ansible|
+        ansible.install_mode = "pip"
+        ansible.version = "2.2"
         ansible.host_vars = { "server#{i}" => { "private_ipv4_address" => "192.168.4.2#{i}0" , "private_ipv6_address" => "fd00::2#{i}0" } }
-        ansible.playbook = "provisioning/servers.yml"
       end
 
     end

--- a/provisioning/RHCSA_RHCE_LAB/defaults/main.yml
+++ b/provisioning/RHCSA_RHCE_LAB/defaults/main.yml
@@ -3,4 +3,5 @@ default_user_password: $6$Q3GYp7hPMnnS$eYYW8MWVIky3A71Isq714ErAjDseEgT6AoedBQz9V
 root_user_password: $6$Q3GYp7hPMnnS$eYYW8MWVIky3A71Isq714ErAjDseEgT6AoedBQz9VY8h4ZyYrbVPi3A.r8sGkbnUqxHb4DFK5GcxuGSw6ojED.
 ipa_ipv4: 192.168.4.200
 ipa_ipv6: fd00::200
+google_dns4: 8.8.8.8
 gui: true

--- a/provisioning/RHCSA_RHCE_LAB/tasks/main.yml
+++ b/provisioning/RHCSA_RHCE_LAB/tasks/main.yml
@@ -22,7 +22,7 @@
   register: ifcfg_eth1_state
 
 - name: modify private connection
-  shell: nmcli connection modify Wired\ connection\ 1 connection.id eth1 ipv4.addresses {{ private_ipv4_address }}/24 ipv4.dns {{ ipa_ipv4 }} ipv6.addresses {{ private_ipv6_address }}/24 ipv6.dns {{ ipa_ipv6 }} ipv4.method manual ipv6.method manual
+  shell: nmcli connection modify Wired\ connection\ 1 connection.id eth1 ipv4.addresses {{ private_ipv4_address }}/24 ipv4.dns {{ ipa_ipv4 }} +ipv4.dns {{ ansible_dns.nameservers[0] }} +ipv4.dns {{ google_dns4 }} ipv6.addresses {{ private_ipv6_address }}/24 ipv6.dns {{ ipa_ipv6 }} ipv4.method manual ipv6.method manual
   when: ifcfg_eth1_state.stat.exists == false
 
 - name: name private connection 'System eth1'
@@ -90,7 +90,7 @@
   yum:
     name="@^Server With GUI"
     state="present"
-  when: inventory_hostname_short == "server1" or inventory_hostname_short == "labipa"
+  when: gui and (inventory_hostname_short == "server1" or inventory_hostname_short == "labipa")
 
 - name: "Set graphical target (runlevel 5) as default"
   shell: systemctl set-default graphical.target

--- a/provisioning/labipa/defaults/main.yml
+++ b/provisioning/labipa/defaults/main.yml
@@ -6,7 +6,7 @@ ipa_ipv6: fd00::200
 network_interfaces:
   - eth0
   - eth1
-primary_dns: 8.8.8.8
+google_dns4: 8.8.8.8
 ipa_realm: "{{ domain_name | upper }}"
 ldap_directory_manager_password: password
 ipa_admin_password: password

--- a/provisioning/labipa/tasks/main.yml
+++ b/provisioning/labipa/tasks/main.yml
@@ -34,7 +34,7 @@
     	--realm={{ ipa_realm }} \
     	--ds-password={{ ldap_directory_manager_password }} \
     	--admin-password={{ ipa_admin_password }} \
-    	--forwarder={{ ansible_dns.nameservers[0] }} \
+    	--forwarder={{ primary_dns }} \
     	--reverse-zone={{ reverse_dns }} \
     	--unattended
     "

--- a/provisioning/labipa/tasks/main.yml
+++ b/provisioning/labipa/tasks/main.yml
@@ -34,10 +34,16 @@
     	--realm={{ ipa_realm }} \
     	--ds-password={{ ldap_directory_manager_password }} \
     	--admin-password={{ ipa_admin_password }} \
-    	--forwarder={{ primary_dns }} \
+    	--forwarder={{ ansible_dns.nameservers[0] }} \
+      --forwarder={{ google_dns4 }}
     	--reverse-zone={{ reverse_dns }} \
     	--unattended
     "
+  when: labipa_status.stat.exists == false
+
+# see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Linux_Domain_Identity_Authentication_and_Policy_Guide/Configuring_IPA_Users-Specifying_Default_User_Settings.html
+- name: change FreeIPA user defaults
+  shell: ipa config-mod --homedirectory /home/ldap --defaultshell /bin/bash --maxusername 32
   when: labipa_status.stat.exists == false
 
 - name: "Start & Enable krb5kdc/firewalld services"


### PR DESCRIPTION
Hi Anwar, local ansible is a good idea. 
- On my macOS virtualbox uses the /vagrant [shared folder](https://www.vagrantup.com/docs/synced-folders/virtualbox.html) and it wouldn't run pointing to /home/vagrant/sync.
- By default vagrant uses the latest version of ansible, which seems fine with me. Any particular reason why you use ansible 2.2? 
- for privacy & surveillance reasons some people prefer not to use 8.8.8.8 although they are excellent dns servers. ansible_dns.nameservers[0] should always work and if you vm host uses 8.8.8.8 it will use 8.8.8.8 anyway. I added all three dns 192.168.4.200, ansible_dns & 8.8.8.8 to show what is possible. What do you think?

Sorry for the confusion, I closed and merged your #14, which was not my intention. Hope we can figure out how to fix my github errors.