### PR TITLE
fix python & pip errors

### DIFF
--- a/provisioning/RHCSA_RHCE_LAB/handlers/main.yml
+++ b/provisioning/RHCSA_RHCE_LAB/handlers/main.yml
@@ -1,3 +1,0 @@
----
-- name: update pip
-  shell: pip install --upgrade pip

--- a/provisioning/RHCSA_RHCE_LAB/tasks/main.yml
+++ b/provisioning/RHCSA_RHCE_LAB/tasks/main.yml
@@ -65,25 +65,28 @@
 - name: enable Extra Packages for Enterprise Linux (epel)
   yum:
     name: epel-release
-    state: present
+    state: latest
+
+- name: update epel-7
+  shell: yum -y update epel-release
 
 - name: Install Bash Completion (for nmcli)
   yum: name={{ item }} state=present
   with_items:
     - libselinux-python
-    - python-pip # for tzupdate
     - bash-completion
-  notify: update pip
 
 - name: pip install tzupdate
   pip:
     name: tzupdate
+  when: not (inventory_hostname_short == "labipa")
 
 # see https://github.com/cdown/tzupdate TODO CentOS GUI can be set to detect timezone, but how can we set this automated?
 - name: set timezone based on geolocation
   shell: /bin/sleep 15; tzupdate # sleep prevents Python error when running tzupdate immediate after install
   async: 60 # takes quite some time
   poll: 0 # we don't need to wait for this to finish
+  when: not (inventory_hostname_short == "labipa")
 
 # TODO GUI boots first time with 'License not accepted' see https://bugs.centos.org/view.php?id=7177
 - name: "Install 'Server With GUI' environment group"

--- a/provisioning/labipa/tasks/main.yml
+++ b/provisioning/labipa/tasks/main.yml
@@ -29,14 +29,14 @@
   shell:
     "
     ipa-server-install \
-    	--setup-dns \
-    	--domain={{ domain_name }} \
-    	--realm={{ ipa_realm }} \
-    	--ds-password={{ ldap_directory_manager_password }} \
-    	--admin-password={{ ipa_admin_password }} \
-    	--forwarder={{ ansible_dns.nameservers[0] }} \
-    	--reverse-zone={{ reverse_dns }} \
-    	--unattended
+      --setup-dns \
+      --domain={{ domain_name }} \
+      --realm={{ ipa_realm }} \
+      --ds-password={{ ldap_directory_manager_password }} \
+      --admin-password={{ ipa_admin_password }} \
+      --forwarder={{ ansible_dns.nameservers[0] }} \
+      --reverse-zone={{ reverse_dns }} \
+      --unattended
     "
   when: labipa_status.stat.exists == false
 
@@ -64,3 +64,15 @@
     - kpasswd
     - dns
     - ntp
+
+- name: pip install tzupdate
+  pip:
+    name: tzupdate
+  when: inventory_hostname_short == "labipa"
+
+# see https://github.com/cdown/tzupdate TODO CentOS GUI can be set to detect timezone, but how can we set this automated?
+- name: set timezone based on geolocation
+  shell: /bin/sleep 15; tzupdate # sleep prevents Python error when running tzupdate immediate after install
+  async: 60 # takes quite some time
+  poll: 0 # we don't need to wait for this to finish
+  when: inventory_hostname_short == "labipa"


### PR DESCRIPTION
Latest Centos/7 box [1610.01](https://seven.centos.org/2016/11/updated-centos-vagrant-images-available-v1610-01/) failed on `ipa-server-install`, fixed with 

- removing pip-install as this caused downgrade to earlier version of pip
- move tzupdate to end of labipa installation as it caused `ipa-server-install` to fail

On server1 `yum -y install ipa-client; ipa-client-install` still generates warning `WARNING: yacc table file version is out of date`. Haven't been able to fix, @AnwarYagoub maybe you can find the solution? 