### PR TITLE
Generic overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,62 +19,62 @@ Don't worry you don't have to be expert on any of these tools.
 **1.1 Install virtualbox on Ubuntu:**
 
 ```shell
-$ wget -q -O - http://download.virtualbox.org/virtualbox/debian/oracle_vbox_2016.asc | sudo apt-key add -
+$ wget -q https://www.virtualbox.org/download/oracle_vbox_2016.asc -O- | sudo apt-key add -
 
-$ sudo sh -c 'echo "deb http://download.virtualbox.org/virtualbox/debian `lsb_release -sc` non-free contrib" > /etc/apt/sources.list.d/virtualbox.org.list'
+$ sudo sh -c 'echo "deb https://download.virtualbox.org/virtualbox/debian `lsb_release -sc` non-free contrib" > /etc/apt/sources.list.d/virtualbox.org.list'
 
 $ sudo apt-get update
 
 $ sudo apt-get install dkms
 
-$ sudo apt-get install virtualbox-5.1
+$ sudo apt-get install virtualbox-5.2
 ```
 **1.2 Install virtualbox on Oracle Linux/RHEL/CentOS:**
 ```shell
 $ wget -q https://www.virtualbox.org/download/oracle_vbox.asc -O- | rpm --import -
 
-$ sudo wget http://download.virtualbox.org/virtualbox/rpm/el/virtualbox.repo -O /etc/yum.repos.d/virtualbox.repo
+$ sudo wget https://download.virtualbox.org/virtualbox/rpm/el/virtualbox.repo -O /etc/yum.repos.d/virtualbox.repo
 
-$ sudo yum install VirtualBox-5.1
+$ sudo yum install VirtualBox-5.2
 ```
 
 **1.3 Install virtualbox on Fedora:**
 ```shell
 $ wget -q https://www.virtualbox.org/download/oracle_vbox.asc -O- | rpm --import -
 
-$ sudo wget http://download.virtualbox.org/virtualbox/rpm/fedora/virtualbox.repo -O /etc/yum.repos.d/virtualbox.repo
+$ sudo wget https://download.virtualbox.org/virtualbox/rpm/fedora/virtualbox.repo -O /etc/yum.repos.d/virtualbox.repo
 
-$ sudo yum install VirtualBox-5.1
+$ sudo yum install VirtualBox-5.2
 ```
 ### 2. Install vagrant :
 
 **2.1 Install vagrant on Debian-based Linux Ubuntu/Mint (64-bit):**
 ```shell
-$ wget https://releases.hashicorp.com/vagrant/1.8.7/vagrant_1.8.7_x86_64.deb
+$ wget https://releases.hashicorp.com/vagrant/2.1.0/vagrant_2.1.0_x86_64.deb
 
-$ sudo dpkg -i vagrant_1.8.6_i686.deb
+$ sudo dpkg -i vagrant_2.1.0_x86_64.deb
 ```
 
 **2.2 Install vagrant on Debian-based distributions Ubuntu/Mint (32-bit):**
 ```shell
-$ wget https://releases.hashicorp.com/vagrant/1.8.7/vagrant_1.8.7_i686.deb
+$ wget https://releases.hashicorp.com/vagrant/2.1.0/vagrant_2.1.0_i686.deb
 
-$ sudo dpkg -i vagrant_1.8.6_i686.deb
+$ sudo dpkg -i vagrant_2.1.0_i686.deb
 ```
 
 **2.3 Install vagrant on RedHat-based distributions (64-bit):**
 ```shell
-$ sudo yum -y install https://releases.hashicorp.com/vagrant/1.8.7/vagrant_1.8.7_x86_64.rpm
+$ sudo yum -y install https://releases.hashicorp.com/vagrant/2.1.0/vagrant_2.1.0_x86_64.rpm
 ```
 
 **2.4 Install vagrant on RedHat-based distributions (32-bit):**
 ```shell
-$ sudo yum -y install https://releases.hashicorp.com/vagrant/1.8.7/vagrant_1.8.7_i686.rpm
+$ sudo yum -y install https://releases.hashicorp.com/vagrant/2.1.0/vagrant_2.1.0_i686.rpm
 ```
 
 ## Get environment
 ```shell
-$ git clone https://github.com/AnwarYagoub/RHCSA-RHCE-Lab-Environment.git
+$ git clone https://github.com/jszigetvari/RHCSA-RHCE-Lab-Environment.git
 
 $ cd RHCSA-RHCE-Lab-Environment
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # configure cache-server machine
   config.vm.define "cache-server" do |node|
     node.vm.box = "debian/jessie64"
-    node.vm.hostname = "cache-server.example.com"
+    node.vm.hostname = "cache-server.example.local"
     node.vm.network "private_network", ip: "192.168.4.100"
     node.vm.provider "virtualbox" do |vb|
       vb.memory = "512"
@@ -35,14 +35,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define "labipa" do |node|
     # machine basic settings
     node.vm.box = "centos/7"
-    node.vm.hostname = "labipa.example.com"
+    node.vm.hostname = "labipa.example.local"
     node.vm.network "private_network", ip: "192.168.4.200", auto_config: false
     # provider specific settings
     node.vm.provider "virtualbox" do |vb|
-      vb.gui = true
       vb.memory = "2048"
       vb.name = "labipa"
     end
+
+    node.vm.provision "shell", inline: <<-SHELL
+                 yum install -y epel-release
+                 yum update -y
+                 yum install -y python-simplejson python-pip
+                 pip install netaddr
+                 SHELL
+
     # provision machine using ansible
     node.vm.provision :ansible_local do |ansible|
       ansible.install_mode = "pip"
@@ -59,12 +66,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # machine basic settings
       node.vm.box = "centos/7"
       # node.vm.box_version = "1509.01"
-      node.vm.hostname = "server#{i}.example.com"
+      node.vm.hostname = "server#{i}.example.local"
       # yes this is a bug in Vagrant: we need to provide the ip-address even if auto_config doesn't use it
       node.vm.network "private_network", ip: "192.168.4.2#{i}0", auto_config: false
       # provider specific settings
       node.vm.provider "virtualbox" do |vb|
-        vb.gui = true
         vb.memory = "1024"
         # Get disk path
         vb.name = "server#{i}"

--- a/provisioning/RHCSA_RHCE_LAB/handlers/main.yml
+++ b/provisioning/RHCSA_RHCE_LAB/handlers/main.yml
@@ -1,3 +1,8 @@
 ---
 - name: update pip
   shell: pip install --upgrade pip
+
+- name: restart sshd
+  service:
+    name: sshd
+    state: restarted

--- a/provisioning/RHCSA_RHCE_LAB/tasks/main.yml
+++ b/provisioning/RHCSA_RHCE_LAB/tasks/main.yml
@@ -40,13 +40,7 @@
     dest: /etc/ssh/sshd_config
     regexp: ^PasswordAuthentication no
     replace: PasswordAuthentication yes
-  register: allow_ssh_password
-
-- name: restart sshd
-  service:
-    name: sshd
-    state: restarted
-  when: allow_ssh_password|succeeded
+  notify: restart sshd
 
 - name: "Add user account & set its password"
   user:
@@ -97,7 +91,7 @@
   when: gui and inventory_hostname_short == "labipa"
   # notify: reboot TODO, for now do a 'vagrant reload' after provisioning
 
-# support 'scp labipa.example.com:/etc/ipa/ca.crt /etc/openldap/cacerts/' p145
+# support 'scp labipa.example.local:/etc/ipa/ca.crt /etc/openldap/cacerts/' p145
 - name: make /etc/openldap/cacerts directory
   file:
     path: /etc/openldap/cacerts

--- a/provisioning/labipa/defaults/main.yml
+++ b/provisioning/labipa/defaults/main.yml
@@ -1,4 +1,4 @@
-domain_name: example.com
+domain_name: example.local
 ipa_hostname: labipa
 ipa_fqdn: "{{ ipa_hostname }}.{{ domain_name }}"
 ipa_ipv4: 192.168.4.200

--- a/provisioning/labipa/tasks/main.yml
+++ b/provisioning/labipa/tasks/main.yml
@@ -4,6 +4,11 @@
     policy="targeted"
     state="permissive"
 
+- name: "remove python urllib3"
+  pip:
+    name: urllib3
+    state: absent
+
 - name: "Install FreeIPA packages"
   yum:
     name="{{ item }}"


### PR DESCRIPTION
Generic overhaul: fixed bugs that prevented me from starting up and provisionings the VMs properly, plus fixed some deprecation warnings, and updated the README. 

README.md:
    * updated installation instructions to current software versions

Vagrantfile:
    * turned off GUI being enabled by default for labipa and the servers
    * changed the domain to example.local because FreeIPA complained about
      example.com being already taken
    * added extra provisioning shell script for labipa
      * there were problems with during Ansible execution with
        ipaddr('revdns') from netaddr, due to netaddr missing
      * the netaddr package thus had to be installed via pip
      * to have pip, the EPEL repo is needed

provisioning/RHCSA_RHCE_LAB/handlers/main.yml:
    * moved the SSH restart code to a handler

provisioning/RHCSA_RHCE_LAB/tasks/main.yml:
    * moved the SSH restart code to a handler
    * changed the domain to example.local

provisioning/labipa/defaults/main.yml:
    * changed the domain to example.local

provisioning/labipa/tasks/main.yml:
    * added task to remove urllib3 via pip
      * it prevented the installation of FreeIPA
      * there was a package conflict between urllib3/pip and
        python-urllib3/rpm

Signed-off-by: Janos SZIGETVARI <jszigetvari@gmail.com>